### PR TITLE
Remove environment config from deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,9 +50,6 @@ jobs:
         path: 'ToDoList/dist/ToDoList/browser'
 
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'


### PR DESCRIPTION
Deleted the 'environment' section from the deploy job in the GitHub Actions workflow. This simplifies the deployment configuration and removes the explicit environment and URL assignment.